### PR TITLE
Added support for screenshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "email": "pepin.greg@gmail.com"
   },
   "dependencies": {
-    "node-trx": "0.4.0"
+    "node-trx": "0.7.0",
+    "node-uuid": "^1.4.7",
+    "mkdirp": "^0.5.1"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Screenshots are saved the same way Visual Studio would save:

- myreport.trx
- myreport
	- In
		- resultTestExecutionId
			- uuid1.png

Sample configuration:

```javascript
jasmine.getEnv().addReporter(new jasmineTrxReporter({
  reportName: 'myreport',
  ...,
  takeScreenshotsOnlyOnFailures: true    
  // Or "takeScreenshots: true" to take screenshots for all specs
 }));
```